### PR TITLE
Update `url` to project GitHub in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     version = __version__,
     author='Chris Mungall',
     author_email='cmungall@gmail.com',
-    url='https://github.com/prefixcommons/prefixcommons',
+    url='https://github.com/prefixcommons/prefixcommons-py',
     description='Library for working prefixcommons.org CURIEs',
     long_description=open("README.rst").read(),
     license='BSD3',


### PR DESCRIPTION
Hi !

The project URL was broken, so clicking "Homepage" on PyPI would not get you here but to a 404 page.