### PR TITLE
Clean up typing and expand_uri implementation

### DIFF
--- a/prefixcommons/curie_util.py
+++ b/prefixcommons/curie_util.py
@@ -2,13 +2,13 @@ import json
 import logging
 from contextlib import closing
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 
 PREFIX_MAP = Dict[str, Any]
 
-this_path = Path(__file__).parent
+HERE = Path(__file__).parent.resolve()
 
 
 class CurieError(Exception):
@@ -18,7 +18,7 @@ class CurieError(Exception):
 class NoExpansion(CurieError):
     """Thrown if no prefix exists."""
 
-    def __init__(self, prefix, id):
+    def __init__(self, prefix: str, id: str):
         self.prefix = prefix
         self.id = id
 
@@ -26,21 +26,21 @@ class NoExpansion(CurieError):
 class NoContraction(CurieError):
     """Thrown if no prefix matches."""
 
-    def __init__(self, uri):
+    def __init__(self, uri: str):
         self.uri = uri
 
 
 class NoPrefix(CurieError):
     """Thrown if no prefix matches."""
 
-    def __init__(self, uri):
+    def __init__(self, uri: str):
         self.uri = uri
 
 
 class AmbiguousPrefix(CurieError):
     """Thrown if multiple prefix matches."""
 
-    def __init__(self, uri, curies):
+    def __init__(self, uri: str, curies: List[str]):
         self.uri = uri
         self.curies = curies
 
@@ -48,15 +48,14 @@ class AmbiguousPrefix(CurieError):
 class InvalidSyntax(CurieError):
     """Thrown if curie does not contain ":" ."""
 
-    def __init__(self, id):
+    def __init__(self, id: str):
         self.id = id
 
 
-def read_local_jsonld_context(fn) -> PREFIX_MAP:
+def read_local_jsonld_context(fn: Union[str, Path]) -> PREFIX_MAP:
     """
     Reads a prefix map from a JSON-LD context file from local disk
     """
-
     with open(fn) as file:
         return extract_prefixmap(json.load(file))
 
@@ -88,7 +87,7 @@ def read_biocontext(name: str) -> PREFIX_MAP:
 
     E.g. monarch_context
     """
-    path_to_jsonld = str(this_path / "registry" / f"{name}.jsonld")
+    path_to_jsonld = HERE / "registry" / f"{name}.jsonld"
     with open(path_to_jsonld) as file:
         return extract_prefixmap(json.load(file))
     # return read_remote_jsonld_context("https://raw.githubusercontent.com/prefixcommons/biocontext/master/registry/"+name+".jsonld")
@@ -101,7 +100,7 @@ default_curie_maps = [
 ]
 
 
-def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None):
+def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None) -> List[str]:
     if cmaps is None:
         cmaps = default_curie_maps
     prefixes = []
@@ -110,7 +109,9 @@ def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None):
     return prefixes
 
 
-def contract_uri(uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, shortest=True):
+def contract_uri(
+    uri: str, cmaps: Optional[List[PREFIX_MAP]] = None, strict: bool = False, shortest: bool = True
+) -> List[str]:
     """
     Contracts a URI/IRI to a CURIE/identifier
 
@@ -119,6 +120,8 @@ def contract_uri(uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, sh
 
     Arguments
     ---------
+    uri:
+        The URI to contract
     cmaps : list
         list of context maps
     strict: boolean
@@ -153,18 +156,21 @@ def contract_uri(uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, sh
     return curies
 
 
-def expand_uri(id, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False):
+def expand_uri(id: str, cmaps: Optional[List[PREFIX_MAP]] = None, strict: bool = False) -> str:
     """
     Expands a CURIE/identifier to a URI
     """
-    if cmaps is None:
-        cmaps = default_curie_maps
-    if id.find(":") == -1:
+    try:
+        prefix, localid = id.split(":", 1)
+    except ValueError:
         if strict:
             raise InvalidSyntax(id)
         else:
             return id
-    [prefix, localid] = id.split(":", 1)
+
+    if cmaps is None:
+        cmaps = default_curie_maps
+
     for cmap in cmaps:
         if prefix in cmap:
             return cmap[prefix] + localid


### PR DESCRIPTION
This PR cleans up type annotations, documentation, and simplifies the implementation of `expand_uri()`. Ideally, #21 should be merged first so this can get unit tested.