### PR TITLE
Use `curies` package for default implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ ENV/
 
 # Jupyter
 .ipynb_checkpoints
+.DS_Store

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,6 +60,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "curies"
+version = "0.1.5"
+description = "Idiomatic conversion between URIs and compact URIs (CURIEs)."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytrie = "*"
+requests = "*"
+
+[package.extras]
+tests = ["coverage", "pytest"]
+docs = ["sphinx-automodapi", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinx"]
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -115,8 +131,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
 
 [[package]]
 name = "py"
@@ -171,6 +187,17 @@ python-versions = "*"
 pytest = ">=2.8.1"
 
 [[package]]
+name = "pytrie"
+version = "0.4.0"
+description = "A pure Python implementation of the trie data structure."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+sortedcontainers = "*"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -195,6 +222,14 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "tomli"
@@ -240,7 +275,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "085bbc94eea19dd6bff501cee254f62793c5426f534fcf11b82bccdb1eee2270"
+content-hash = "b525c429ec5878319c2a2034aa9ce0500fba6c517e10dfb8a55ffccaa54e6dc7"
 
 [metadata.files]
 atomicwrites = [
@@ -266,6 +301,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+curies = [
+    {file = "curies-0.1.5-py3-none-any.whl", hash = "sha256:5500f0c8faccb0c8a6d70dbe275668dbb6dd3c4a4013424a337a52074f647d6a"},
+    {file = "curies-0.1.5.tar.gz", hash = "sha256:d03186119f01c76d19f91f3de2003c652280a81e6d71f4c31c2a927a82c727bf"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -301,6 +340,9 @@ pytest = [
 ]
 pytest-logging = [
     {file = "pytest-logging-2015.11.4.tar.gz", hash = "sha256:cec5c85ecf18aab7b2ead5498a31b9f758680ef5a902b9054ab3f2bdbb77c896"},
+]
+pytrie = [
+    {file = "PyTrie-0.4.0.tar.gz", hash = "sha256:8f4488f402d3465993fb6b6efa09866849ed8cda7903b50647b7d0342b805379"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -340,6 +382,10 @@ pyyaml = [
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/prefixcommons/curie_util.py
+++ b/prefixcommons/curie_util.py
@@ -110,7 +110,7 @@ default_converter = curies.chain(
 
 def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None) -> List[str]:
     if cmaps is None:
-        return list(default_converter.get_prefixes())
+        return sorted(default_converter.get_prefixes())
     prefixes = []
     for cmap in cmaps:
         prefixes += cmap.keys()
@@ -144,9 +144,12 @@ def contract_uri(
     if cmaps is None:
         # TODO warn if not shortest?
         curie = default_converter.compress(uri)
-        if curie is None and strict:
+        if curie is not None:
+            return [curie]
+        elif strict:
             raise NoPrefix(uri)
-        return [curie]
+        else:
+            return []
 
     curies = set()
     for cmap in cmaps:
@@ -181,9 +184,12 @@ def expand_uri(id, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False):
 
     if cmaps is None:
         uri = default_converter.compress(id)
-        if uri is None and strict:
+        if uri is not None:
+            return uri
+        elif strict:
             raise NoExpansion
-        return uri
+        else:
+            return id
 
     for cmap in cmaps:
         if prefix in cmap:

--- a/prefixcommons/curie_util.py
+++ b/prefixcommons/curie_util.py
@@ -109,7 +109,7 @@ default_converter = curies.chain(
 
 def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None) -> List[str]:
     if cmaps is None:
-        return sorted(default_converter.get_prefixes())
+        return list(default_converter.get_prefixes())
     prefixes = []
     for cmap in cmaps:
         prefixes += cmap.keys()

--- a/prefixcommons/curie_util.py
+++ b/prefixcommons/curie_util.py
@@ -117,7 +117,9 @@ def get_prefixes(cmaps: Optional[List[PREFIX_MAP]] = None) -> List[str]:
     return prefixes
 
 
-def contract_uri(uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, shortest=True):
+def contract_uri(
+    uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, shortest=True
+) -> List[str]:
     """
     Contracts a URI/IRI to a CURIE/identifier
 
@@ -140,10 +142,11 @@ def contract_uri(uri, cmaps: Optional[List[PREFIX_MAP]] = None, strict=False, sh
 
     """
     if cmaps is None:
-        res = default_converter.compress(uri)
-        if res is None and strict:
+        # TODO warn if not shortest?
+        curie = default_converter.compress(uri)
+        if curie is None and strict:
             raise NoPrefix(uri)
-        return res
+        return [curie]
 
     curies = set()
     for cmap in cmaps:

--- a/prefixcommons/curie_util.py
+++ b/prefixcommons/curie_util.py
@@ -184,11 +184,11 @@ def expand_uri(id: str, cmaps: Optional[List[PREFIX_MAP]] = None, strict: bool =
             return id
 
     if cmaps is None:
-        uri = default_converter.compress(id)
+        uri = default_converter.expand(curie=id)
         if uri is not None:
             return uri
         elif strict:
-            raise NoExpansion
+            raise NoExpansion(prefix, localid)
         else:
             return id
 
@@ -196,6 +196,6 @@ def expand_uri(id: str, cmaps: Optional[List[PREFIX_MAP]] = None, strict: bool =
         if prefix in cmap:
             return cmap[prefix] + localid
     if strict:
-        raise NoExpansion(prefix, id)
+        raise NoExpansion(prefix, localid)
     else:
         return id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requests = "^2.28.1"
 click = "^8.1.3"
 pytest-logging = "^2015.11.4"
 PyYAML = "^6.0"
+curies = "^0.1.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
Closes #5 

This PR uses the [`curies`](https://github.com/cthoyt/curies) package to provide a much faster default implementation for expansion and contraction that uses the `trie` data structure. This doesn't address the case where users bring their own custom prefix maps, as this data structure needs to be pre-built.